### PR TITLE
Update .gitignore to ignore Obsidian directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Obsidian
+.obsidian/
+
 .virtual_documents
 
 /prof/


### PR DESCRIPTION
Just added an entry to .gitignore to not track Obsidian's vault directory. Several files within this directory, especially workplace.json, change quite often and aren't relevant to the script's function.